### PR TITLE
最小SDKバージョンを変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "intern.line.me.kyotoaclient"
-        minSdkVersion 24
+        minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
minSdkVersionを24から23に変更しました。
Android6.0でも動くようになります。