### PR TITLE
メッセージ関係の実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     def coroutines_version = '0.22.5'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
+
+    implementation "com.google.dagger:dagger:2.12"
+    annotationProcessor "com.google.dagger:dagger-compiler:2.12"
+    kapt "com.google.dagger:dagger-compiler:2.12"
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -15,16 +15,17 @@ import intern.line.me.kyotoaclient.lib.Room
 import intern.line.me.kyotoaclient.lib.User
 import intern.line.me.kyotoaclient.lib.api.GetMessages
 import intern.line.me.kyotoaclient.lib.api.adapters.MessagesAdapter
-import intern.line.me.kyotoaclient.lib.api.interfaces.GetMessagesInActivity
 import java.sql.Time
 import java.sql.Timestamp
 import java.util.*
 
-class MessageActivity : GetMessagesInActivity() {
+class MessageActivity : AppCompatActivity() {
     private val MESSAGE_EDIT_EVENT = 0
     private val MESSAGE_DELETE_EVENT = 1
     private var editingMessagePosition: Int? = null
-    override var messages: MessageList? = null
+
+    var messages: MessageList? = null
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -154,7 +155,7 @@ class MessageActivity : GetMessagesInActivity() {
         this.toSendMode()
     }
 
-    private fun drawMessagesList(scrollAt: Int? = null) {
+    fun drawMessagesList(scrollAt: Int? = null) {
         var messages = this.messages
         messages = messages ?: MessageList(mutableListOf(Message(
                 id = 1L,
@@ -190,9 +191,4 @@ class MessageActivity : GetMessagesInActivity() {
     private fun getRoom(id: Long): Room{
         return Room(1, "my group", Timestamp(47389732489), Timestamp(47389732489), "message", Timestamp(47989732489))
     }
-
-    override fun doMessagesAction() {
-        drawMessagesList()
-    }
-
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -12,6 +12,8 @@ import intern.line.me.kyotoaclient.adapter.MessageListAdapter
 import intern.line.me.kyotoaclient.lib.Message
 import intern.line.me.kyotoaclient.lib.MessageList
 import intern.line.me.kyotoaclient.lib.Room
+import intern.line.me.kyotoaclient.lib.api.GetMessages
+import intern.line.me.kyotoaclient.lib.api.adapters.MessagesAdapter
 import java.sql.Timestamp
 import java.util.*
 
@@ -20,104 +22,7 @@ class MessageActivity : AppCompatActivity() {
     private val MESSAGE_DELETE_EVENT = 1
     private var editingMessagePosition: Int? = null
 
-    private var messages: MessageList = MessageList(mutableListOf(
-            Message(
-                    id = 1,
-                    room_id = 1,
-                    user_id = 1,
-                    text = "foundgfsauygfoeufiovbreyiaofgbysadrofvbywoabfvisobveiosbahgiovlsabuigpvp;bsauviprfbgeauvifbvuilaboggvuifdb",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 2,
-                    room_id = 1,
-                    user_id = 2,
-                    text = "hello 1!",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 3,
-                    room_id = 1,
-                    user_id = 1,
-                    text = "どうよ",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 4,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "わーい",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 5,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "たーのしー！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 6,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "かばんちゃん！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 7,
-                    room_id = 1,
-                    user_id = 5,
-                    text = "サーバルちゃん！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 8,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "たーのしー！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 9,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "すごくたーのしー！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 10,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "めっちゃたーのしー！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 11,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "やばたーのしー！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            ),
-            Message(
-                    id = 8,
-                    room_id = 1,
-                    user_id = 4,
-                    text = "たーのしー！",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
-            )
-    ))
+    private var messages: MessageList? = null
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -126,6 +31,11 @@ class MessageActivity : AppCompatActivity() {
         val roomId = intent.getLongExtra("roomId", -1)
         val room: Room = getRoom(roomId)
         this.title = room.name
+        val adapter = MessagesAdapter()
+        GetMessages(adapter, roomId).start()
+        if (adapter.messages != null){
+            messages = MessageList(adapter.messages as MutableList<Message>)
+        }
         this.drawMessagesList()
     }
 
@@ -153,15 +63,19 @@ class MessageActivity : AppCompatActivity() {
     }
 
     private fun onDeleteMessage(id: Int): Boolean {
-        this.messages.removeAt(id)
+        this.messages?.removeAt(id)
         this.drawMessagesList()
         return true
+    }
+
+    fun onUpdate(v: View) {
+        println(this.messages)
     }
 
     private fun onUpdateMessage(id: Int): Boolean {
         this.toEditMode(id)
         val editInput: EditText = findViewById(R.id.message_edit_text)
-        val message: Message = this.messages.messageAt(id)
+        val message: Message = this.messages?.messageAt(id) ?: return true
         editInput.setText(message.text)
 
         return true
@@ -196,7 +110,7 @@ class MessageActivity : AppCompatActivity() {
             return
         }
         val editText: EditText = findViewById(R.id.message_edit_text)
-        val originMessage: Message = this.messages.messageAt(editingMessagePosition)
+        val originMessage: Message = this.messages?.messageAt(editingMessagePosition) ?: return
         if (originMessage.text == editText.text.toString()){
             this.toSendMode()
             return
@@ -207,7 +121,7 @@ class MessageActivity : AppCompatActivity() {
         var message = originMessage
         message.text = editText.text.toString()
         message.updatedAt = Timestamp(System.currentTimeMillis())
-        this.messages.updateAt(editingMessagePosition, message)
+        this.messages?.updateAt(editingMessagePosition, message)
         originMessage.update(message)
         this.drawMessagesList()
         this.toSendMode()
@@ -227,17 +141,25 @@ class MessageActivity : AppCompatActivity() {
                 createdAt = created_at,
                 updatedAt = created_at
         )
-        this.messages.add(newMessage)
+        this.messages?.add(newMessage)
         this.drawMessagesList()
         this.toSendMode()
     }
 
     private fun drawMessagesList(scrollAt: Int? = null) {
-        val messages = this.messages
+        var messages = this.messages
+        messages = messages ?: MessageList(mutableListOf(Message(
+                id = 1L,
+                room_id = 1L,
+                user_id = 1L,
+                text = "ss",
+                createdAt = Timestamp(1L),
+                updatedAt = Timestamp(1L)
+        )))
         val adapter = MessageListAdapter(this)
         adapter.setMessages(messages)
         val listView: ListView = this.findViewById(R.id.main_list)
-        var scrollTo: Int = 0
+        var scrollTo = 0
         if (scrollAt == null) {
             scrollTo = listView.count - 1
         } else {

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -12,8 +12,10 @@ import intern.line.me.kyotoaclient.adapter.MessageListAdapter
 import intern.line.me.kyotoaclient.lib.Message
 import intern.line.me.kyotoaclient.lib.MessageList
 import intern.line.me.kyotoaclient.lib.Room
+import intern.line.me.kyotoaclient.lib.User
 import intern.line.me.kyotoaclient.lib.api.GetMessages
 import intern.line.me.kyotoaclient.lib.api.adapters.MessagesAdapter
+import java.sql.Time
 import java.sql.Timestamp
 import java.util.*
 
@@ -138,6 +140,12 @@ class MessageActivity : AppCompatActivity() {
                 id = Random().nextLong(),
                 room_id = 1,
                 user_id = 4,
+                user = User(
+                        id = 4,
+                        name = "hoge",
+                        created_at = Timestamp(1L),
+                        updated_at = Timestamp(1L)
+                ),
                 text = sendText.text.toString(),
                 created_at = created_at,
                 updated_at = created_at
@@ -154,6 +162,12 @@ class MessageActivity : AppCompatActivity() {
                 room_id = 1L,
                 user_id = 1L,
                 text = "ss",
+                user = User(
+                        id = 4,
+                        name = "hoge",
+                        created_at = Timestamp(1L),
+                        updated_at = Timestamp(1L)
+                ),
                 created_at = Timestamp(1L),
                 updated_at = Timestamp(1L)
         )))

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -191,4 +191,8 @@ class MessageActivity : AppCompatActivity() {
     private fun getRoom(id: Long): Room{
         return Room(1, "my group", Timestamp(47389732489), Timestamp(47389732489), "message", Timestamp(47989732489))
     }
+
+    fun doMessagesAction() {
+        drawMessagesList()
+    }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -226,11 +226,20 @@ class MessageActivity : AppCompatActivity() {
         messagePool.stopMessagePool()
     }
 
+    override fun onRestart() {
+        super.onRestart()
+        val room = room
+        val messagePool = messagePool
+        room ?: return
+        messagePool ?: return
+        messagePool.getPool(room.id)
+    }
+
     fun scrollToEnd(v: View) {
         val listView: ListView = this.findViewById(R.id.main_list)
         val messages = messages
         messages ?: return
-        val last: Int = messages.count - 1
+        val last: Int = messages.count.toInt() - 1
         listView.setSelection(last)
     }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -33,7 +33,7 @@ class MessageActivity : AppCompatActivity() {
         val roomId = intent.getLongExtra("roomId", -1)
         val room: Room = getRoom(roomId)
         this.title = room.name
-        MessagesAdapter(this).execute(roomId)
+        MessagesAdapter(this).get(roomId)
     }
 
     override fun onCreateContextMenu(menu: ContextMenu?, v: View?, menuInfo: ContextMenu.ContextMenuInfo?) {

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -157,23 +157,15 @@ class MessageActivity : AppCompatActivity() {
 
     fun drawMessagesList(scrollAt: Int? = null) {
         var messages = this.messages
-        messages = messages ?: MessageList(mutableListOf(Message(
-                id = 1L,
-                room_id = 1L,
-                user_id = 1L,
-                text = "ss",
-                user = User(
-                        id = 4,
-                        name = "hoge",
-                        created_at = Timestamp(1L),
-                        updated_at = Timestamp(1L)
-                ),
-                created_at = Timestamp(1L),
-                updated_at = Timestamp(1L)
-        )))
+        val listView: ListView = this.findViewById(R.id.main_list)
+        val progress: View = this.findViewById(R.id.message_loading)
+        if (messages == null) {
+            listView.visibility = View.INVISIBLE
+            progress.visibility = View.VISIBLE
+            return
+        }
         val adapter = MessageListAdapter(this)
         adapter.setMessages(messages)
-        val listView: ListView = this.findViewById(R.id.main_list)
         var scrollTo = 0
         if (scrollAt == null) {
             scrollTo = listView.count - 1
@@ -183,7 +175,6 @@ class MessageActivity : AppCompatActivity() {
         listView.adapter = adapter
         listView.setSelection(scrollTo)
         registerForContextMenu(listView)
-        val progress: View = this.findViewById(R.id.message_loading)
         listView.visibility = View.VISIBLE
         progress.visibility = View.INVISIBLE
     }

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -49,6 +49,7 @@ class MessageActivity : AppCompatActivity() {
         val adapterInfo: AdapterView.AdapterContextMenuInfo = menuInfo as AdapterView.AdapterContextMenuInfo
         val listView: ListView = v as ListView
         val messageObj = listView.getItemAtPosition(adapterInfo.position) as Message
+        // TODO("myIdをちゃんと取得する")
         val myId: Long = 1
         if (messageObj.user_id == myId){
             menu?.setHeaderTitle(messageObj.text)

--- a/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/MessageActivity.kt
@@ -15,17 +15,16 @@ import intern.line.me.kyotoaclient.lib.Room
 import intern.line.me.kyotoaclient.lib.User
 import intern.line.me.kyotoaclient.lib.api.GetMessages
 import intern.line.me.kyotoaclient.lib.api.adapters.MessagesAdapter
+import intern.line.me.kyotoaclient.lib.api.interfaces.GetMessagesInActivity
 import java.sql.Time
 import java.sql.Timestamp
 import java.util.*
 
-class MessageActivity : AppCompatActivity() {
+class MessageActivity : GetMessagesInActivity() {
     private val MESSAGE_EDIT_EVENT = 0
     private val MESSAGE_DELETE_EVENT = 1
     private var editingMessagePosition: Int? = null
-
-    var messages: MessageList? = null
-
+    override var messages: MessageList? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -155,7 +154,7 @@ class MessageActivity : AppCompatActivity() {
         this.toSendMode()
     }
 
-    fun drawMessagesList(scrollAt: Int? = null) {
+    private fun drawMessagesList(scrollAt: Int? = null) {
         var messages = this.messages
         messages = messages ?: MessageList(mutableListOf(Message(
                 id = 1L,
@@ -191,4 +190,9 @@ class MessageActivity : AppCompatActivity() {
     private fun getRoom(id: Long): Room{
         return Room(1, "my group", Timestamp(47389732489), Timestamp(47389732489), "message", Timestamp(47989732489))
     }
+
+    override fun doMessagesAction() {
+        drawMessagesList()
+    }
+
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/RoomCreateActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/RoomCreateActivity.kt
@@ -20,56 +20,56 @@ class RoomCreateActivity : AppCompatActivity() {
             User(
                     id = 1,
                     name = "User1",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 2,
                     name = "User2",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 3,
                     name = "User3",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 4,
                     name = "User4",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 5,
                     name = "User5",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 6,
                     name = "User6",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 7,
                     name = "User7",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 8,
                     name = "User8",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             ),
             User(
                     id = 9,
                     name = "User9",
-                    createdAt = Timestamp(439208349),
-                    updatedAt = Timestamp(439208349)
+                    created_at = Timestamp(439208349),
+                    updated_at = Timestamp(439208349)
             )
     ))
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
@@ -30,7 +30,7 @@ class MessageListAdapter(private val context: Context): BaseAdapter() {
     }
 
     override fun getCount(): Int {
-        return messages?.count ?: 0
+        return messages?.count?.toInt() ?: 0
     }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
@@ -32,14 +32,14 @@ class MessageListAdapter(private val context: Context): BaseAdapter() {
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {
         var convertView = layoutInflater.inflate(R.layout.message_ballon, parent, false)
         val message: Message = messages?.messageAt(position) ?: throw Exception("message not found")
-        val created_at: Timestamp = (message.createdAt)
+        val created_at: Timestamp = (message.created_at)
         val format = SimpleDateFormat("HH:mm")
         val time = Date(created_at.time)
 
         (convertView.findViewById(R.id.message_author) as TextView).setText(message.user_id.toString())
         (convertView.findViewById(R.id.message_text) as TextView).setText((message.text))
         (convertView.findViewById(R.id.message_time) as TextView).setText(format.format(time))
-        if (message.createdAt != message.updatedAt){
+        if (message.created_at != message.updated_at){
             (convertView.findViewById(R.id.message_modified) as TextView).visibility = View.VISIBLE
         }
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
@@ -25,6 +25,10 @@ class MessageListAdapter(private val context: Context): BaseAdapter() {
         this.messages = messages
     }
 
+    fun getMessages(): MessageList? {
+        return this.messages
+    }
+
     override fun getCount(): Int {
         return messages?.count ?: 0
     }
@@ -53,5 +57,4 @@ class MessageListAdapter(private val context: Context): BaseAdapter() {
     override fun getItemId(position: Int): Long {
         return messages?.messageAt(position)?.id ?: throw Exception("message not found")
     }
-
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/MessageListAdapter.kt
@@ -36,7 +36,7 @@ class MessageListAdapter(private val context: Context): BaseAdapter() {
         val format = SimpleDateFormat("HH:mm")
         val time = Date(created_at.time)
 
-        (convertView.findViewById(R.id.message_author) as TextView).setText(message.user_id.toString())
+        (convertView.findViewById(R.id.message_author) as TextView).setText(message.user.name)
         (convertView.findViewById(R.id.message_text) as TextView).setText((message.text))
         (convertView.findViewById(R.id.message_time) as TextView).setText(format.format(time))
         if (message.created_at != message.updated_at){

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
@@ -1,6 +1,7 @@
 package intern.line.me.kyotoaclient.lib
 
 import java.sql.Timestamp
+import java.util.concurrent.atomic.AtomicInteger
 
 class Message(
     var id: Long,
@@ -13,7 +14,7 @@ class Message(
 )
 
 class MessageList(val messages: MutableList<Message>) {
-    var count: Int = messages.count()
+    var count: AtomicInteger = AtomicInteger(messages.count())
 
     fun messageAt(index: Int): Message {
         return this.messages[index]
@@ -41,6 +42,6 @@ class MessageList(val messages: MutableList<Message>) {
     }
 
     private fun updateCount() {
-        this.count = this.messages.count()
+        this.count.set(this.messages.count())
     }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
@@ -36,6 +36,10 @@ class MessageList(val messages: MutableList<Message>) {
         return true
     }
 
+    fun getLast(): Message {
+        return this.messages[this.messages.lastIndex]
+    }
+
     private fun updateCount() {
         this.count = this.messages.count()
     }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
@@ -9,6 +9,7 @@ class Message(
     var room_id: Long,
     var user_id: Long,
     var text: String,
+    var user: User,
     var created_at: Timestamp,
     var updated_at: Timestamp
 ) {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
@@ -9,8 +9,8 @@ class Message(
     var room_id: Long,
     var user_id: Long,
     var text: String,
-    var createdAt: Timestamp,
-    var updatedAt: Timestamp
+    var created_at: Timestamp,
+    var updated_at: Timestamp
 ) {
     fun update(message: Message) {
         MessageUpdate(this, message).start()

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
@@ -1,7 +1,7 @@
 package intern.line.me.kyotoaclient.lib
 
-import intern.line.me.kyotoaclient.lib.api.Delete
-import intern.line.me.kyotoaclient.lib.api.Update
+import intern.line.me.kyotoaclient.lib.api.MessageDelete
+import intern.line.me.kyotoaclient.lib.api.MessageUpdate
 import java.sql.Timestamp
 
 class Message(
@@ -13,11 +13,11 @@ class Message(
     var updatedAt: Timestamp
 ) {
     fun update(message: Message) {
-        Update(this, message).start()
+        MessageUpdate(this, message).start()
     }
 
     fun delete() {
-        Delete(this).start()
+        MessageDelete(this).start()
     }
 }
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/Message.kt
@@ -1,7 +1,5 @@
 package intern.line.me.kyotoaclient.lib
 
-import intern.line.me.kyotoaclient.lib.api.MessageDelete
-import intern.line.me.kyotoaclient.lib.api.MessageUpdate
 import java.sql.Timestamp
 
 class Message(
@@ -12,17 +10,9 @@ class Message(
     var user: User,
     var created_at: Timestamp,
     var updated_at: Timestamp
-) {
-    fun update(message: Message) {
-        MessageUpdate(this, message).start()
-    }
+)
 
-    fun delete() {
-        MessageDelete(this).start()
-    }
-}
-
-class MessageList(private val messages: MutableList<Message>) {
+class MessageList(val messages: MutableList<Message>) {
     var count: Int = messages.count()
 
     fun messageAt(index: Int): Message {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/User.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/User.kt
@@ -5,8 +5,8 @@ import java.sql.Timestamp
 data class User(
         var id: Long,
         var name: String,
-        var createdAt: Timestamp,
-        var updatedAt: Timestamp
+        var created_at: Timestamp,
+        var updated_at: Timestamp
 )
 
 class UserList(private val users: MutableList<User>) {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Message.kt
@@ -1,8 +1,12 @@
 package intern.line.me.kyotoaclient.lib.api
 
 import android.util.Log
+import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
+import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.lib.Message
+import intern.line.me.kyotoaclient.lib.MessageList
+import intern.line.me.kyotoaclient.lib.api.adapters.MessagesAdapter
 import intern.line.me.kyotoaclient.lib.api.interfaces.MessagesAPI
 import intern.line.me.kyotoaclient.lib.firebase.FirebaseUtil
 import kotlinx.coroutines.experimental.withContext
@@ -10,8 +14,10 @@ import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import retrofit2.HttpException
+import java.io.IOException
+import java.net.SocketTimeoutException
 
-class MessageUpdate(private var message: Message, private val newMessage: Message): API() {
+class UpdateMessage(private val context: MessagesAdapter, private val position: Int, private var message: Message, private val newMessage: Message): API() {
     val api = retrofit.create(MessagesAPI::class.java)
 
     private suspend fun updateAsyncMessage(token: String, newMessage: Message): Message = withContext(CommonPool) {
@@ -20,12 +26,47 @@ class MessageUpdate(private var message: Message, private val newMessage: Messag
 
     private suspend fun updateMessage(newMessage: Message) {
         val token: String? = FirebaseUtil().getIdToken()
-        token ?: throw Exception("message update failed")
+        if (token == null) {
+            context.responseCode = 500
+            context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+            context.goBack()
+            return
+        }
         try {
             val resMessage = updateAsyncMessage(token, newMessage)
-            message = resMessage
+            context.responseCode = 200
+            val messages = context.messages
+            if (messages == null) {
+                context.handler.post {
+                    context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+                    context.goBack()
+                }
+                return
+            }
+            // update
+            messages[position] = resMessage
+            context.messages = messages
+            context.handler.post {
+                context.doMessagesAction()
+            }
         } catch (t: HttpException) {
-            throw Exception("message update failed")
+            context.responseCode = t.response().code()
+            context.handler.post {
+                context.makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
+                context.goBack()
+            }
+        } catch (t: SocketTimeoutException) {
+            context.responseCode = 500
+            context.handler.post {
+                context.makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
+                context.goBack()
+            }
+        } catch (t: IOException) {
+            context.responseCode = 500
+            context.handler.post {
+                context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+                context.goBack()
+            }
         }
     }
 
@@ -40,22 +81,62 @@ class MessageUpdate(private var message: Message, private val newMessage: Messag
     }
 }
 
-class MessageDelete(private var message: Message): API() {
+class DeleteMessage(private val context: MessagesAdapter, private val position: Int, private var message: Message): API() {
     val api = retrofit.create(MessagesAPI::class.java)
 
-    private suspend fun deleteAsyncMessage(token: String, message: Message): Boolean = withContext(CommonPool) {
+    private suspend fun deleteAsyncMessage(token: String, message: Message): HashMap<String, Boolean> = withContext(CommonPool) {
         api.deleteMessage(token, message.id).await()
     }
 
     private suspend fun deleteMessage(message: Message): Boolean {
         val token: String? = FirebaseUtil().getIdToken()
-        token ?: throw Exception("message update failed")
+        if (token == null) {
+            context.responseCode = 500
+            context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+            context.goBack()
+            return false
+        }
         try {
             val res = deleteAsyncMessage(token, message)
-            return res
-        } catch (t: Throwable) {
-            throw Exception("message deletion failed")
+            context.responseCode = 200
+            val messages = context.messages
+            if (messages == null) {
+                context.handler.post {
+                    context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+                    context.goBack()
+                }
+                return false
+            }
+            val resResult = res["result"]
+            resResult ?: throw IOException()
+            if (resResult) {
+                messages.removeAt(position)
+            }
+            context.messages = messages
+            context.handler.post {
+                context.doMessagesAction()
+            }
+            return true
+        } catch (t: HttpException) {
+            context.responseCode = t.response().code()
+            context.handler.post {
+                context.makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
+                context.goBack()
+            }
+        } catch (t: SocketTimeoutException) {
+            context.responseCode = 500
+            context.handler.post {
+                context.makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
+                context.goBack()
+            }
+        } catch (t: IOException) {
+            context.responseCode = 500
+            context.handler.post {
+                context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+                context.goBack()
+            }
         }
+        return false
     }
 
     override fun start() {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Message.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Message.kt
@@ -27,6 +27,7 @@ class UpdateMessage(private val context: MessagesAdapter, private val position: 
     private suspend fun updateMessage(newMessage: Message) {
         val token: String? = FirebaseUtil().getIdToken()
         if (token == null) {
+            Log.v("MESSAGE_UPDATER", "API failed: i have no token")
             context.responseCode = 500
             context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
             context.goBack()
@@ -37,6 +38,7 @@ class UpdateMessage(private val context: MessagesAdapter, private val position: 
             context.responseCode = 200
             val messages = context.messages
             if (messages == null) {
+                Log.v("MESSAGE_UPDATER", "API failed: there are no messages for update")
                 context.handler.post {
                     context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
                     context.goBack()
@@ -50,18 +52,21 @@ class UpdateMessage(private val context: MessagesAdapter, private val position: 
                 context.doMessagesAction()
             }
         } catch (t: HttpException) {
+            Log.v("MESSAGE_UPDATER", "API failed: 403 forbidden")
             context.responseCode = t.response().code()
             context.handler.post {
                 context.makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: SocketTimeoutException) {
+            Log.v("MESSAGE_UPDATER", "API failed: timeout")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: IOException) {
+            Log.v("MESSAGE_UPDATER", "API failed: unknown reason")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
@@ -91,6 +96,7 @@ class DeleteMessage(private val context: MessagesAdapter, private val position: 
     private suspend fun deleteMessage(message: Message): Boolean {
         val token: String? = FirebaseUtil().getIdToken()
         if (token == null) {
+            Log.v("MESSAGE_DELETER", "API failed: i have no token")
             context.responseCode = 500
             context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
             context.goBack()
@@ -101,6 +107,7 @@ class DeleteMessage(private val context: MessagesAdapter, private val position: 
             context.responseCode = 200
             val messages = context.messages
             if (messages == null) {
+                Log.v("MESSAGE_DELETER", "API failed: there are no message to delete")
                 context.handler.post {
                     context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
                     context.goBack()
@@ -118,18 +125,21 @@ class DeleteMessage(private val context: MessagesAdapter, private val position: 
             }
             return true
         } catch (t: HttpException) {
+            Log.v("MESSAGE_DELETER", "API failed: 403 forbidden")
             context.responseCode = t.response().code()
             context.handler.post {
                 context.makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: SocketTimeoutException) {
+            Log.v("MESSAGE_DELETER", "API failed: timeout")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: IOException) {
+            Log.v("MESSAGE_DELETER", "API failed: unknown reason")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Room.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Room.kt
@@ -26,8 +26,8 @@ class GetMessages (private val context: MessagesAdapter, private val room_id:Lon
         token ?: throw Exception("message update failed")
         try {
             val resMessages = getAsyncMessages(token, room_id)
-            context.responseCode = 200
             context.messages = resMessages as MutableList<Message>?
+            context.responseCode = 200
         } catch (t: HttpException) {
             context.responseCode = t.response().code()
             return

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Room.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Room.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.launch
 import retrofit2.HttpException
 import java.net.ConnectException
+import java.net.SocketTimeoutException
 
 
 class GetMessages (private val context: MessagesAdapter, private val room_id:Long): API() {
@@ -31,6 +32,9 @@ class GetMessages (private val context: MessagesAdapter, private val room_id:Lon
             context.responseCode = t.response().code()
             return
         } catch (t: ConnectException) {
+            context.responseCode = 500
+            return
+        } catch (t: SocketTimeoutException) {
             context.responseCode = 500
             return
         }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Room.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/Room.kt
@@ -1,5 +1,6 @@
 package intern.line.me.kyotoaclient.lib.api
 
+import android.util.Log
 import android.widget.Toast
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
@@ -31,6 +32,7 @@ class GetMessages (private val context: MessagesAdapter, private val room_id:Lon
     private suspend fun getMessages(room_id: Long) {
         val token: String? = FirebaseUtil().getIdToken()
         if (token == null) {
+            Log.v("ROOM_MESSAGES_GETTER", "API failed: i have no token")
             context.responseCode = 500
             context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
             context.goBack()
@@ -45,18 +47,21 @@ class GetMessages (private val context: MessagesAdapter, private val room_id:Lon
                 context.doMessagesAction()
             }
         } catch (t: HttpException) {
+            Log.v("ROOM_MESSAGES_GETTER", "API failed: 403 forbibdden")
             context.responseCode = t.response().code()
             context.handler.post {
                 context.makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: SocketTimeoutException) {
+            Log.v("ROOM_MESSAGES_GETTER", "API failed: timeout")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: IOException) {
+            Log.v("ROOM_MESSAGES_GETTER", "API failed: unknown reason")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
@@ -122,6 +127,7 @@ class CreateMessage (private val context: MessagesAdapter, private val room_id:L
     private suspend fun createMessage(room_id: Long, text: String) {
         val token: String? = FirebaseUtil().getIdToken()
         if (token == null) {
+            Log.v("ROOM_MESSAGES_CREATER", "API failed: i have no token")
             context.responseCode = 500
             context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)
             context.goBack()
@@ -135,18 +141,21 @@ class CreateMessage (private val context: MessagesAdapter, private val room_id:L
                 context.doMessagesAction(-1)
             }
         } catch (t: HttpException) {
+            Log.v("ROOM_MESSAGES_CREATER", "API failed: 403 forbidden")
             context.responseCode = t.response().code()
             context.handler.post {
                 context.makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: SocketTimeoutException) {
+            Log.v("ROOM_MESSAGES_CREATER", "API failed: timeout")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
                 context.goBack()
             }
         } catch (t: IOException) {
+            Log.v("ROOM_MESSAGES_CREATER", "API failed: unknown reason")
             context.responseCode = 500
             context.handler.post {
                 context.makeToast(R.string.api_failed, Toast.LENGTH_LONG)

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -25,6 +25,7 @@ class MessagesAdapter(private var activity: MessageActivity) {
     }
 
     fun getPool(roomId: Long): MessagesAdapter {
+        running = true
         messagePool = GetMessages(this, roomId).startPool()
         return this
     }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -44,9 +44,7 @@ class MessagesAdapter(var activity: MessageActivity): AsyncTask<Long, Int, Unit>
             makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
             goBack()
             return
-        }
-        // 500えらーとか400以外のエラー
-        if (activity.messages == null) {
+        } else if (responseCode != 200) {
             makeToast(R.string.api_failed, Toast.LENGTH_LONG)
             goBack()
             return

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -13,7 +13,7 @@ class MessagesAdapter(var activity: MessageActivity) {
     var responseCode: Int? = null
     val handler = Handler()
 
-    fun execute(roomId: Long) {
+    fun get(roomId: Long) {
         GetMessages(this, roomId).start()
     }
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -8,9 +8,10 @@ import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.lib.Message
 import intern.line.me.kyotoaclient.lib.MessageList
 import intern.line.me.kyotoaclient.lib.api.GetMessages
+import intern.line.me.kyotoaclient.lib.api.interfaces.GetMessagesInActivity
 import java.lang.Thread.sleep
 
-class MessagesAdapter(var activity: MessageActivity): AsyncTask<Long, Int, Unit>() {
+class MessagesAdapter(var activity: GetMessagesInActivity): AsyncTask<Long, Int, Unit>() {
     var messages: MutableList<Message>? = null
     var responseCode: Int? = null
 
@@ -49,7 +50,7 @@ class MessagesAdapter(var activity: MessageActivity): AsyncTask<Long, Int, Unit>
             goBack()
             return
         }
-        activity.drawMessagesList()
+        activity.doMessagesAction()
     }
 
     private fun makeToast(string_id: Int, show: Int) {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -1,7 +1,65 @@
 package intern.line.me.kyotoaclient.lib.api.adapters
 
+import android.os.AsyncTask
+import android.view.KeyEvent
+import android.widget.Toast
+import intern.line.me.kyotoaclient.MessageActivity
+import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.lib.Message
+import intern.line.me.kyotoaclient.lib.MessageList
+import intern.line.me.kyotoaclient.lib.api.GetMessages
+import java.lang.Thread.sleep
 
-class MessagesAdapter {
-    var messages: List<Message>? = null
+class MessagesAdapter(var activity: MessageActivity): AsyncTask<Long, Int, Unit>() {
+    var messages: MutableList<Message>? = null
+    var responseCode: Int? = null
+
+    override fun doInBackground(vararg params: Long?) {
+        val roomId = params[0] ?: throw Exception("no room id")
+        GetMessages(this, roomId).start()
+        for (i in 1..100) {
+            // 100 * 100ミリ秒間まつ
+            sleep(100)
+            // APIリクエストの動作が完了していればresponsecodeがある
+            if (responseCode != null) {
+                // 200の場合messagesがnot null
+                if (messages != null){
+                    val mes = messages
+                    activity.messages = MessageList(mes ?: break)
+                }
+                break
+            }
+        }
+        return
+    }
+
+    override fun onPostExecute(res: Unit) {
+        super.onPostExecute(res)
+        if (responseCode == null) {
+            makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
+            goBack()
+            return
+        }
+        if (responseCode == 400) {
+            makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
+            goBack()
+            return
+        }
+        // 500えらーとか400以外のエラー
+        if (activity.messages == null) {
+            makeToast(R.string.api_failed, Toast.LENGTH_LONG)
+            goBack()
+            return
+        }
+        activity.drawMessagesList()
+    }
+
+    private fun makeToast(string_id: Int, show: Int) {
+        Toast.makeText(activity, string_id, show).show()
+    }
+
+    private fun goBack() {
+        activity.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK))
+        activity.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK))
+    }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -8,10 +8,9 @@ import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.lib.Message
 import intern.line.me.kyotoaclient.lib.MessageList
 import intern.line.me.kyotoaclient.lib.api.GetMessages
-import intern.line.me.kyotoaclient.lib.api.interfaces.GetMessagesInActivity
 import java.lang.Thread.sleep
 
-class MessagesAdapter(var activity: GetMessagesInActivity): AsyncTask<Long, Int, Unit>() {
+class MessagesAdapter(var activity: MessageActivity): AsyncTask<Long, Int, Unit>() {
     var messages: MutableList<Message>? = null
     var responseCode: Int? = null
 
@@ -50,7 +49,7 @@ class MessagesAdapter(var activity: GetMessagesInActivity): AsyncTask<Long, Int,
             goBack()
             return
         }
-        activity.doMessagesAction()
+        activity.drawMessagesList()
     }
 
     private fun makeToast(string_id: Int, show: Int) {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -6,15 +6,30 @@ import android.widget.Toast
 import intern.line.me.kyotoaclient.MessageActivity
 import intern.line.me.kyotoaclient.lib.Message
 import intern.line.me.kyotoaclient.lib.MessageList
+import intern.line.me.kyotoaclient.lib.api.CreateMessage
+import intern.line.me.kyotoaclient.lib.api.DeleteMessage
 import intern.line.me.kyotoaclient.lib.api.GetMessages
+import intern.line.me.kyotoaclient.lib.api.UpdateMessage
 
-class MessagesAdapter(var activity: MessageActivity) {
-    var messages: MutableList<Message>? = null
+class MessagesAdapter(private var activity: MessageActivity) {
+    var messages: MutableList<Message>? = activity.messages?.messages
     var responseCode: Int? = null
     val handler = Handler()
 
     fun get(roomId: Long) {
         GetMessages(this, roomId).start()
+    }
+
+    fun create(roomId: Long, text: String) {
+        CreateMessage(this, roomId, text).start()
+    }
+
+    fun update(position: Int, originMessage: Message, newMessage: Message) {
+        UpdateMessage(this, position, originMessage, newMessage).start()
+    }
+
+    fun delete(position: Int, message: Message) {
+        DeleteMessage(this, position, message).start()
     }
 
     fun makeToast(string_id: Int, show: Int) {

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -1,0 +1,7 @@
+package intern.line.me.kyotoaclient.lib.api.adapters
+
+import intern.line.me.kyotoaclient.lib.Message
+
+class MessagesAdapter {
+    var messages: List<Message>? = null
+}

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/adapters/MessagesAdapter.kt
@@ -1,63 +1,38 @@
 package intern.line.me.kyotoaclient.lib.api.adapters
 
-import android.os.AsyncTask
+import android.os.Handler
 import android.view.KeyEvent
 import android.widget.Toast
 import intern.line.me.kyotoaclient.MessageActivity
-import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.lib.Message
 import intern.line.me.kyotoaclient.lib.MessageList
 import intern.line.me.kyotoaclient.lib.api.GetMessages
-import java.lang.Thread.sleep
 
-class MessagesAdapter(var activity: MessageActivity): AsyncTask<Long, Int, Unit>() {
+class MessagesAdapter(var activity: MessageActivity) {
     var messages: MutableList<Message>? = null
     var responseCode: Int? = null
+    val handler = Handler()
 
-    override fun doInBackground(vararg params: Long?) {
-        val roomId = params[0] ?: throw Exception("no room id")
+    fun execute(roomId: Long) {
         GetMessages(this, roomId).start()
-        for (i in 1..100) {
-            // 100 * 100ミリ秒間まつ
-            sleep(100)
-            // APIリクエストの動作が完了していればresponsecodeがある
-            if (responseCode != null) {
-                // 200の場合messagesがnot null
-                if (messages != null){
-                    val mes = messages
-                    activity.messages = MessageList(mes ?: break)
-                }
-                break
-            }
-        }
-        return
     }
 
-    override fun onPostExecute(res: Unit) {
-        super.onPostExecute(res)
-        if (responseCode == null) {
-            makeToast(R.string.api_timeout, Toast.LENGTH_LONG)
-            goBack()
-            return
-        }
-        if (responseCode == 400) {
-            makeToast(R.string.api_forbidden, Toast.LENGTH_LONG)
-            goBack()
-            return
-        } else if (responseCode != 200) {
-            makeToast(R.string.api_failed, Toast.LENGTH_LONG)
-            goBack()
-            return
-        }
-        activity.drawMessagesList()
-    }
-
-    private fun makeToast(string_id: Int, show: Int) {
+    fun makeToast(string_id: Int, show: Int) {
         Toast.makeText(activity, string_id, show).show()
     }
 
-    private fun goBack() {
+    fun goBack() {
         activity.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_BACK))
         activity.dispatchKeyEvent(KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_BACK))
+    }
+
+    fun doMessagesAction() {
+        val messages =  this.messages
+        if (messages == null) {
+            activity.messages = null
+        } else {
+            activity.messages = MessageList(messages)
+        }
+        activity.doMessagesAction()
     }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/GetMessagesInActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/GetMessagesInActivity.kt
@@ -1,0 +1,9 @@
+package intern.line.me.kyotoaclient.lib.api.interfaces
+
+import android.support.v7.app.AppCompatActivity
+import intern.line.me.kyotoaclient.lib.MessageList
+
+abstract class GetMessagesInActivity: AppCompatActivity() {
+    abstract var messages: MessageList?
+    abstract fun doMessagesAction ()
+}

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/GetMessagesInActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/GetMessagesInActivity.kt
@@ -1,9 +1,0 @@
-package intern.line.me.kyotoaclient.lib.api.interfaces
-
-import android.support.v7.app.AppCompatActivity
-import intern.line.me.kyotoaclient.lib.MessageList
-
-abstract class GetMessagesInActivity: AppCompatActivity() {
-    abstract var messages: MessageList?
-    abstract fun doMessagesAction ()
-}

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/messages.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/messages.kt
@@ -15,5 +15,5 @@ interface MessagesAPI {
     fun deleteMessage(
         @Header("Token") token : String,
         @Path("id") id: Long
-    ): Deferred<Boolean>
+    ): Deferred<HashMap<String, Boolean>>
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/messages.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/messages.kt
@@ -1,20 +1,19 @@
 package intern.line.me.kyotoaclient.lib.api.interfaces
 import intern.line.me.kyotoaclient.lib.Message
 import kotlinx.coroutines.experimental.Deferred
-import retrofit2.http.Body
-import retrofit2.http.DELETE
-import retrofit2.http.PUT
-import retrofit2.http.Path
+import retrofit2.http.*
 
 interface MessagesAPI {
     @PUT("/messages/{id}")
     fun updateMessage(
+        @Header("Token") token : String,
         @Path("id") id: Long,
         @Body body: HashMap<String, String>
     ): Deferred<Message>
 
     @DELETE("/messages/{id}")
     fun deleteMessage(
+        @Header("Token") token : String,
         @Path("id") id: Long
     ): Deferred<Boolean>
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/rooms.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/rooms.kt
@@ -9,4 +9,11 @@ interface RoomsAPI {
         @Header("Token") token : String,
         @Path("id") id: Long
     ): Deferred<List<Message>>
+
+    @POST("/rooms/{id}/messages")
+    fun createMessage(
+        @Header("Token") token : String,
+        @Path("id") id: Long,
+        @Body body: HashMap<String, String>
+    ): Deferred<Message>
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/rooms.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/rooms.kt
@@ -6,6 +6,7 @@ import retrofit2.http.*
 interface RoomsAPI {
     @GET("/rooms/{id}/messages")
     fun getMessages(
+        @Header("Token") token : String,
         @Path("id") id: Long
     ): Deferred<List<Message>>
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/firebase/FirebaseUtil.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/firebase/FirebaseUtil.kt
@@ -5,6 +5,7 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.FirebaseUser
 
 class FirebaseUtil{
+    var ret: Any? = null
     companion object {
         val auth = FirebaseAuth.getInstance()!!
         private var token : String? = null
@@ -32,7 +33,7 @@ class FirebaseUtil{
             if (it.isSuccessful) {
                 token = it.result.token
                 Log.d("Token", token)
-                body()
+                ret = body()
             }else{
                 throw Exception("can't get token.")
             }

--- a/app/src/main/res/layout/activity_message.xml
+++ b/app/src/main/res/layout/activity_message.xml
@@ -10,7 +10,9 @@
         android:id="@+id/linearLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="#c0c0ff"
         android:orientation="vertical"
+        android:visibility="visible"
         app:layout_constraintBottom_toTopOf="parent"
         app:layout_constraintEnd_toStartOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -21,8 +23,8 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="#c0c0ff"
-            android:divider="@null">
+            android:divider="@null"
+            android:visibility="invisible">
 
         </ListView>
 
@@ -78,11 +80,30 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:onClick="onSend"
+                    android:onClick="onUpdate"
                     android:text="@string/message_send" />
             </LinearLayout>
         </FrameLayout>
 
     </LinearLayout>
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ProgressBar
+            android:id="@+id/message_loading"
+            style="@style/Widget.AppCompat.ProgressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </RelativeLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_message.xml
+++ b/app/src/main/res/layout/activity_message.xml
@@ -18,15 +18,36 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <ListView
-            android:id="@+id/main_list"
+        <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"
-            android:divider="@null"
-            android:visibility="invisible">
+            android:layout_height="match_parent"
+            android:layout_weight="1">
 
-        </ListView>
+            <ListView
+                android:id="@+id/main_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_weight="1"
+                android:divider="@null"
+                android:visibility="invisible">
+
+            </ListView>
+
+            <TextView
+                android:id="@+id/message_new_notify"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom"
+                android:background="#bbbbbbaa"
+                android:gravity="center"
+                android:onClick="scrollToEnd"
+                android:paddingBottom="3dp"
+                android:paddingTop="3dp"
+                android:text="@string/message_new_available"
+                android:textSize="18sp"
+                android:visibility="visible" />
+
+        </FrameLayout>
 
         <FrameLayout
             android:id="@+id/message_inputs_layout"
@@ -104,6 +125,7 @@
             style="@style/Widget.AppCompat.ProgressBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
+
     </RelativeLayout>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_message.xml
+++ b/app/src/main/res/layout/activity_message.xml
@@ -80,7 +80,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:onClick="onUpdate"
+                    android:onClick="onSend"
                     android:text="@string/message_send" />
             </LinearLayout>
         </FrameLayout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,4 +9,5 @@
     <string name="api_forbidden">権限がありません</string>
     <string name="api_timeout">タイムアウトしました</string>
     <string name="api_failed">API接続に失敗しました</string>
+    <string name="message_new_available">新しいメッセージがあります</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -6,4 +6,7 @@
     <string name="edit">編集</string>
     <string name="delete">削除</string>
     <string name="message_modified">編集済</string>
+    <string name="api_forbidden">権限がありません</string>
+    <string name="api_timeout">タイムアウトしました</string>
+    <string name="api_failed">API接続に失敗しました</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="api_forbidden">You don\'t have permission</string>
     <string name="api_timeout">timeout error</string>
     <string name="api_failed">api connection failed</string>
+    <string name="message_new_available">New message are exists</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,4 +10,7 @@
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
     <string name="message_modified">Modified</string>
+    <string name="api_forbidden">You don\'t have permission</string>
+    <string name="api_timeout">timeout error</string>
+    <string name="api_failed">api connection failed</string>
 </resources>


### PR DESCRIPTION
### Enhancement
- APIを使って以下のことができます
  - ルームIDよりメッセージ一覧の取得
  - ルームIDでメッセージの送信
  - メッセージの編集
  - メッセージの削除
- MessageActivityの変更
  - APIの呼び出し中に、ローディング画面を表示することによってユーザー体験を向上させます
  - 今やMessagesは決め打ちでなく、サーバーから取得されます
  - 今や以下のことはローカルで完結せず、サーバーに適切に反映されます
    - Messagesの送信
    - Messagesの編集
    - Messagesの削除

### Problem
- Userの情報を取得するAPIは未作成なため、my IDが取得できていません
- これに伴い、myId変数は決め打ちです