### PR TITLE
ユーザーの作成時にレスポンスコードによって処理を分けるようにしました

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:logging-interceptor:3.4.1'
     implementation 'com.squareup.okhttp3:okhttp:3.4.1'
     implementation 'com.jakewharton.retrofit:retrofit2-kotlin-coroutines-experimental-adapter:1.0.0'
+    implementation 'ru.gildor.coroutines:kotlin-coroutines-retrofit:0.12.0'
 
     def coroutines_version = '0.22.5'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/UserPresenter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/UserPresenter.kt
@@ -1,5 +1,6 @@
 package intern.line.me.kyotoaclient.lib.api
 
+import android.util.Log
 import com.google.firebase.auth.FirebaseAuth
 import intern.line.me.kyotoaclient.AuthActivity
 import intern.line.me.kyotoaclient.lib.User
@@ -10,9 +11,11 @@ import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import kotlinx.coroutines.experimental.withContext
 import retrofit2.HttpException
+import retrofit2.Response
+import ru.gildor.coroutines.retrofit.awaitResponse
 
 //一つのメソッドに対して一つのクラスを作成。引数はクラスのコンストラクタを利用
-class CreateUserPresenter(val name: String): API(){
+class CreateUserPresenter(val name: String,private val activity: AuthActivity): API(){
     private val api = retrofit.create(UserAPI::class.java)
 
     //FirebaseUtilのインスタンスを作成しないとトークンが共有できない
@@ -29,7 +32,19 @@ class CreateUserPresenter(val name: String): API(){
 
         try {
             if (token != null) {
-                createASyncUser(name, token)
+                val res = createASyncUser(name, token)
+
+                if(res.isSuccessful) {
+                    //res.body()でUserオブジェクトを取得できる(今回は使わない)
+                    activity.onCompleteSignIn()
+
+                }else{
+                    //res.code()でレスポンスコードを取得できる
+                    Log.d("createUser",res.code().toString())
+
+                    activity.showFaildToSignIn()
+                }
+
             } else {
                 throw Exception("can't get token.")
             }

--- a/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/UserAPI.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/lib/api/interfaces/UserAPI.kt
@@ -1,7 +1,7 @@
 package intern.line.me.kyotoaclient.lib.api.interfaces
 
 import intern.line.me.kyotoaclient.lib.User
-import kotlinx.coroutines.experimental.Deferred
+import retrofit2.Call
 import retrofit2.http.POST
 import retrofit2.http.Query
 import retrofit2.http.Header
@@ -12,5 +12,5 @@ interface UserAPI{
     fun createUser(
             @Query("name") name: String,
             @Header("Token") token : String
-    ) : Deferred<User>
+    ) : Call<User>
 }

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -1,11 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    android:id="@+id/sign_in_container"
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/sign_in_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="intern.line.me.kyotoaclient.AuthActivity">
 
-</RelativeLayout>
+    <ProgressBar
+        android:id="@+id/auth_progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/retry_sign_in_button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="@color/colorPrimaryDark"
+        android:elevation="0dp"
+        android:text="@string/retry"
+        android:textColor="@android:color/white"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/faild_to_sign_in_textview"
+        app:layout_constraintStart_toStartOf="@+id/faild_to_sign_in_textview"
+        app:layout_constraintTop_toBottomOf="@+id/auth_progress_bar" />
+
+    <TextView
+        android:id="@+id/faild_to_sign_in_textview"
+        android:layout_width="wrap_content"
+        android:layout_height="23dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/failed_to_sign_in"
+        android:textSize="20sp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toTopOf="@+id/auth_progress_bar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_message.xml
+++ b/app/src/main/res/layout/activity_message.xml
@@ -21,7 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="#c0c0ff"
+            android:background="?android:attr/windowBackground"
             android:divider="@null">
 
         </ListView>

--- a/app/src/main/res/layout/activity_room_create.xml
+++ b/app/src/main/res/layout/activity_room_create.xml
@@ -46,7 +46,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="#c0c0ff"
+            android:background="?android:attr/windowBackground"
             android:divider="@null"></ListView>
 
     </LinearLayout>

--- a/app/src/main/res/layout/activity_room_list.xml
+++ b/app/src/main/res/layout/activity_room_list.xml
@@ -21,7 +21,7 @@
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
-            android:background="#c0c0ff"
+            android:background="?android:attr/windowBackground"
             android:divider="@null"></ListView>
 
     </LinearLayout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -6,4 +6,6 @@
     <string name="edit">編集</string>
     <string name="delete">削除</string>
     <string name="message_modified">編集済</string>
+    <string name="retry">もう一度試す</string>
+    <string name="failed_to_sign_in">ログインに失敗しました</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,12 +2,12 @@
     <string name="app_name">Kyotoaclient</string>
     <string name="room_create_input">Room Name</string>
     <string name="room_create_button">Create</string>
-    <string name="hello_login_text_View">ログイン方法を選択してください</string>
-    <string name="request_client_id">129455307189-1p8npv3edhllc5p9nrt3i7kif4irlvkp.apps.googleusercontent.com</string>
     <string name="message_input">Input text</string>
     <string name="message_send">Send</string>
     <string name="message_edit">Edit</string>
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>
     <string name="message_modified">Modified</string>
+    <string name="retry">Retry</string>
+    <string name="failed_to_sign_in">Failed to sign in</string>
 </resources>


### PR DESCRIPTION
## 実装内容
- 今までは直接`User`をAPIで取得するようになってましたが、`Response<User>`を返すように変更しました。
- これによりレスポンスコードに応じて処理を切り替えることができるようになりました。
- サーバーサイドでユーザーを作成できなかった場合、再度ログインを促すようになりました。