### PR TITLE
UserとRoomのadapterをRealmBaseAdapterに変更しました

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     implementation "com.squareup.retrofit2:adapter-rxjava:$retrofitVersion"
     implementation "com.squareup.retrofit2:converter-gson:$retrofitVersion"
 
+    compile 'io.realm:android-adapters:2.1.1'
+
 }
 
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/intern/line/me/kyotoaclient/activity/RoomCreateActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/activity/RoomCreateActivity.kt
@@ -21,6 +21,7 @@ class RoomCreateActivity : AppCompatActivity() {
     lateinit var me: User
 
     private val job = Job()
+    private val presenter = GetUserList()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -28,26 +29,15 @@ class RoomCreateActivity : AppCompatActivity() {
         setContentView(R.layout.activity_room_create)
 
         //アダプターの設定
-        adapter = UserSelectListAdapter(this)
-        user_select_list.adapter = adapter
         registerForContextMenu(user_select_list)
 
         //先にDBから取得
         launch(job + UI) {
             //TODO(ここボトルネック自分の情報をローカルに取りに行きたい)
             me = GetMyInfo().getMyInfo()
-
-            val users = GetUserList().getUsersList()
-
-            val filteredUserList = mutableListOf<User>()
-            //自分を除外する
-            users.forEach {
-                if (it.id != me.id) {
-                    filteredUserList.add(it)
-                }
-            }
-            adapter.setUsers(filteredUserList)
         }
+        adapter = UserSelectListAdapter(applicationContext,presenter.getUsersListExcludeId(5))
+        user_select_list.adapter = adapter
     }
 
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/activity/RoomCreateActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/activity/RoomCreateActivity.kt
@@ -37,7 +37,7 @@ class RoomCreateActivity : AppCompatActivity() {
             //TODO(ここボトルネック自分の情報をローカルに取りに行きたい)
             me = GetMyInfo().getMyInfo()
 
-            val users = GetUserList().getUsersListFromDb()
+            val users = GetUserList().getUsersList()
 
             val filteredUserList = mutableListOf<User>()
             //自分を除外する

--- a/app/src/main/java/intern/line/me/kyotoaclient/activity/RoomListActivity.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/activity/RoomListActivity.kt
@@ -25,6 +25,7 @@ class RoomListActivity : AppCompatActivity() {
 
 
     private val job = Job()
+	private val presenter = GetRooms()
 
     lateinit var adapter: RoomListAdapter
 
@@ -34,7 +35,7 @@ class RoomListActivity : AppCompatActivity() {
         setContentView(R.layout.activity_room_list)
         setResult(Activity.RESULT_CANCELED)
 
-        adapter = RoomListAdapter(this)
+        adapter = RoomListAdapter(this,presenter.getRoomsFromDB())
         val listView: ListView = this.findViewById(R.id.room_list)
         listView.adapter = adapter
         registerForContextMenu(listView)
@@ -44,9 +45,9 @@ class RoomListActivity : AppCompatActivity() {
 
         //ルームをクリックしたらトークに飛ぶ
         listView.setOnItemClickListener { parent, view, position, id ->
-            val selectedRoom = adapter.getItem(position)
+            val selected_room_id = adapter.getItemId(position)
             val intent = Intent(this, MessageActivity::class.java)
-            intent.putExtra("room_id", selectedRoom.id)
+            intent.putExtra("room_id", selected_room_id)
             startActivity(intent)
         }
 
@@ -73,25 +74,11 @@ class RoomListActivity : AppCompatActivity() {
         job.cancel()
     }
 
+    //非同期でルーム取得
     private fun setAsyncRooms(){
-        //非同期でルーム取得
-        launch(job + UI) {
-
-            //DBから取得
-            GetRooms().getRoomsFromDB().let {
-                setRooms(it)
-            }
-        }
 
         launch(job + UI){
-             GetRooms().getRooms().let{
-                 setRooms(it)
-            }
+             GetRooms().getRooms()
         }
-    }
-
-    private fun setRooms(rooms : List<Room>){
-        adapter.setRooms(rooms)
-        adapter.notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/RoomListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/RoomListAdapter.kt
@@ -5,51 +5,42 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.BaseAdapter
 import android.content.Context
+import android.widget.ListAdapter
 import android.widget.TextView
 import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.model.entity.Message
 import intern.line.me.kyotoaclient.model.entity.Room
+import intern.line.me.kyotoaclient.model.entity.User
+import io.realm.RealmBaseAdapter
+import io.realm.RealmResults
 import java.sql.Date
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 
-class RoomListAdapter(private val context: Context): BaseAdapter() {
+class RoomListAdapter(private val context: Context, realm_results: RealmResults<Room>) : RealmBaseAdapter<Room>(realm_results), ListAdapter {
     var layoutInflater: LayoutInflater
-
-    private var rooms: List<Room> = emptyList()
 
     init {
         this.layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
     }
 
-    fun setRooms(set_rooms: List<Room>){
-        rooms = set_rooms
-        notifyDataSetChanged()
-    }
-
-    override fun getCount(): Int {
-        return rooms.size
-    }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {
         var convertView = layoutInflater.inflate(R.layout.room_display, parent, false)
         val format = SimpleDateFormat("HH:mm")
-        val lastMessage: Message? = rooms[position].last_message
+        val lastMessage: Message? = adapterData!![position].last_message
         if (lastMessage != null) {
             val created_at: Timestamp = Timestamp(lastMessage.created_at.time)
             val time = Date(created_at.time)
-            (convertView.findViewById(R.id.message_time_view) as TextView).setText(format.format(time))
-            (convertView.findViewById(R.id.latest_message_view) as TextView).setText((lastMessage.text))
+            (convertView.findViewById(R.id.message_time_view) as TextView).text = format.format(time)
+            (convertView.findViewById(R.id.latest_message_view) as TextView).text = lastMessage.text
         }
-        (convertView.findViewById(R.id.room_name_view) as TextView).setText((rooms[position].name ?: throw Exception("room not found")))
+        (convertView.findViewById(R.id.room_name_view) as TextView).text = adapterData!![position].name
         return convertView
     }
 
-    override fun getItem(position: Int): Room {
-        return rooms[position] ?: throw Exception("room not found")
-    }
 
     override fun getItemId(position: Int): Long {
-        return rooms[position].id ?: throw Exception("room not found")
+        return super.getItem(position)?.id ?: 0
     }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/UserListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/UserListAdapter.kt
@@ -3,49 +3,34 @@ package intern.line.me.kyotoaclient.adapter
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.BaseAdapter
 import android.content.Context
-import android.util.Log
+import android.widget.ListAdapter
 import android.widget.TextView
 import intern.line.me.kyotoaclient.R
 import intern.line.me.kyotoaclient.model.entity.User
-
-class UserListAdapter(private val context: Context): BaseAdapter() {
+import io.realm.OrderedRealmCollection
+import io.realm.RealmBaseAdapter
+class UserListAdapter(private val context: Context, private val realm_results : OrderedRealmCollection<User>) : RealmBaseAdapter<User>(realm_results), ListAdapter {
     var layoutInflater: LayoutInflater
-
-    private var users: List<User> = emptyList()
 
     init {
         this.layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
     }
 
-
-    override fun getCount(): Int {
-        return users.size
+    override fun getItemId(position: Int): Long {
+        return super.getItem(position)?.id ?: 0
     }
+
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {
-        var convertView = layoutInflater.inflate(R.layout.user_list_row, parent, false)
-        try {
-            (convertView.findViewById(R.id.name_text) as TextView).setText(users[position].name)
-            (convertView.findViewById(R.id.name_icon) as TextView).setText(users[position].name.substring(0, 1))
-        }catch(t : Throwable){
-            Log.d("UserListAdapter",t.toString())
+
+        var convertView = convertView
+                ?: layoutInflater.inflate(R.layout.user_list_row, parent, false)
+        if (adapterData != null) {
+            val user = adapterData!![position]
+            (convertView.findViewById(R.id.name_text) as TextView).text = user.name
+            (convertView.findViewById(R.id.name_icon) as TextView).text = user.name.substring(0, 1)
         }
         return convertView
-    }
-
-    override fun getItem(position: Int): User {
-        return users[position]
-    }
-
-    override fun getItemId(position: Int): Long {
-        return users[position].id
-    }
-
-
-    fun setUsers(set_users: List<User>){
-        users = set_users
-        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/adapter/UserSelectListAdapter.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/adapter/UserSelectListAdapter.kt
@@ -7,61 +7,50 @@ import android.widget.BaseAdapter
 import android.content.Context
 import intern.line.me.kyotoaclient.R
 import android.widget.CheckedTextView
+import android.widget.ListAdapter
 import intern.line.me.kyotoaclient.model.entity.User
+import io.realm.OrderedRealmCollection
+import io.realm.RealmBaseAdapter
 
-class UserSelectListAdapter(private val context: Context): BaseAdapter() {
+class UserSelectListAdapter(private val context: Context,private val realm_results : OrderedRealmCollection<User>): RealmBaseAdapter<User>(realm_results), ListAdapter{
     var layoutInflater: LayoutInflater
 
-    private var users: List<User> = emptyList()
-    private var checkList = mutableListOf<Boolean>()
+    var  checkList : MutableList<Boolean>
 
     init {
         this.layoutInflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
-    }
-
-
-    override fun getCount(): Int {
-        return users.size
+        this. checkList = MutableList<Boolean>(count,{false})
     }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {
-        var convertView = layoutInflater.inflate(R.layout.user_select, parent, false)
+        var convertView = convertView?: layoutInflater.inflate(R.layout.user_select, parent, false)
         val checkView: CheckedTextView = convertView.findViewById(R.id.user_name_view)
-        checkView.text = users[position].name
+        checkView.text = adapterData!![position].name
 
-        checkView.isChecked = checkList[position]
         checkView.setOnClickListener {
             val view = it as CheckedTextView
             view.toggle()
             checkList[position] = view.isChecked
         }
+        checkView.isChecked = checkList[position]
+
         return convertView
     }
 
-    override fun getItem(position: Int): User {
-        return users[position]
-    }
 
     override fun getItemId(position: Int): Long {
-        return users[position].id
+        return super.getItem(position)?.id ?: 0
     }
 
-
-    fun setUsers(set_users: List<User>){
-        users = set_users
-        // 初期化
-        checkList = MutableList(count, { false })
-        notifyDataSetChanged()
-    }
 
     fun getCheckedUserList(): List<User> {
-        if (users.count() != checkList.count()) {
+        if (adapterData!!.count() != checkList.count()) {
             throw Exception("invailed data")
         }
         val selectedUsers = mutableListOf<User>()
-        for (i in 0..(users.count() - 1)){
+        for (i in 0..(adapterData!!.count() - 1)){
             if (checkList[i]){
-                selectedUsers.add(users[i])
+                selectedUsers.add(adapterData!![i])
             }
         }
         return selectedUsers

--- a/app/src/main/java/intern/line/me/kyotoaclient/model/repository/RoomRepository.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/model/repository/RoomRepository.kt
@@ -3,6 +3,7 @@ package intern.line.me.kyotoaclient.model.repository
 import intern.line.me.kyotoaclient.model.entity.Room
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.RealmResults
 import io.realm.Sort
 
 class RoomRepository {
@@ -17,14 +18,8 @@ class RoomRepository {
 		return r_room
 	}
 
-	fun getAll(): List<Room> {
-		val rooms: MutableList<Room> = mutableListOf<Room>()
-		val db_rooms = mRealm.where(Room::class.java).findAll().sort("created_at", Sort.ASCENDING)
-
-		db_rooms.forEach {
-			rooms.add(it)!!
-		}
-		return rooms
+	fun getAll(): RealmResults<Room> {
+		return mRealm.where(Room::class.java).findAll().sort("created_at", Sort.ASCENDING)
 	}
 
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/model/repository/UserRepository.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/model/repository/UserRepository.kt
@@ -3,6 +3,7 @@ package intern.line.me.kyotoaclient.model.repository
 import intern.line.me.kyotoaclient.model.entity.User
 import io.realm.Realm
 import io.realm.RealmConfiguration
+import io.realm.RealmResults
 import io.realm.Sort
 
 class UserRepository {
@@ -21,14 +22,12 @@ class UserRepository {
 		return  mRealm.where(User::class.java).equalTo("id", id).findFirst()
 	}
 
-	fun getAll() : List<User> {
-		val users: MutableList<User> = mutableListOf<User>()
-		val db_users = mRealm.where(User::class.java).findAll().sort("id", Sort.ASCENDING)
+	fun getAll() : RealmResults<User> {
+		return  mRealm.where(User::class.java).sort("id", Sort.ASCENDING).findAll()
+	}
 
-		db_users.forEach{
-			users.add(it)
-		}
-		return users
+	fun getUsersFromName(name: String) : RealmResults<User>{
+		return mRealm.where(User::class.java).contains("name",name).findAll()
 	}
 
 

--- a/app/src/main/java/intern/line/me/kyotoaclient/model/repository/UserRepository.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/model/repository/UserRepository.kt
@@ -22,6 +22,10 @@ class UserRepository {
 		return  mRealm.where(User::class.java).equalTo("id", id).findFirst()
 	}
 
+	fun getUsersListExcludeId(id: Long): RealmResults<User>{
+		return mRealm.where(User::class.java).notEqualTo("id",id).findAll()
+	}
+
 	fun getAll() : RealmResults<User> {
 		return  mRealm.where(User::class.java).sort("id", Sort.ASCENDING).findAll()
 	}

--- a/app/src/main/java/intern/line/me/kyotoaclient/presenter/room/GetRooms.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/presenter/room/GetRooms.kt
@@ -5,6 +5,7 @@ import intern.line.me.kyotoaclient.lib.firebase.FirebaseUtil
 import intern.line.me.kyotoaclient.model.entity.Room
 import intern.line.me.kyotoaclient.model.repository.RoomRepository
 import intern.line.me.kyotoaclient.presenter.API
+import io.realm.RealmResults
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.withContext
 import retrofit2.HttpException
@@ -33,7 +34,7 @@ class GetRooms: API(){
 		}
 	}
 
-	suspend fun getRoomsFromDB() : List<Room>{
+	fun getRoomsFromDB() : RealmResults<Room>{
 		return repo.getAll()
 	}
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/presenter/user/GetUserList.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/presenter/user/GetUserList.kt
@@ -4,6 +4,7 @@ import intern.line.me.kyotoaclient.lib.api.interfaces.UserAPI
 import intern.line.me.kyotoaclient.model.entity.User
 import intern.line.me.kyotoaclient.model.repository.UserRepository
 import intern.line.me.kyotoaclient.presenter.API
+import io.realm.RealmResults
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.withContext
 import retrofit2.HttpException
@@ -29,7 +30,7 @@ class GetUserList: API() {
 		}
 	}
 
-	fun getUsersListFromDb(): List<User> {
+	fun getUsersListFromDb(): RealmResults<User> {
 			return repo.getAll()
 	}
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/presenter/user/GetUserList.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/presenter/user/GetUserList.kt
@@ -33,4 +33,8 @@ class GetUserList: API() {
 	fun getUsersListFromDb(): RealmResults<User> {
 			return repo.getAll()
 	}
+
+	fun getUsersListExcludeId(id : Long): RealmResults<User> {
+		return repo.getUsersListExcludeId(id)
+	}
 }

--- a/app/src/main/java/intern/line/me/kyotoaclient/presenter/user/SearchUsers.kt
+++ b/app/src/main/java/intern/line/me/kyotoaclient/presenter/user/SearchUsers.kt
@@ -2,26 +2,33 @@ package intern.line.me.kyotoaclient.presenter.user
 
 import intern.line.me.kyotoaclient.lib.api.interfaces.UserAPI
 import intern.line.me.kyotoaclient.model.entity.User
+import intern.line.me.kyotoaclient.model.repository.UserRepository
 import intern.line.me.kyotoaclient.presenter.API
+import io.realm.RealmResults
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.withContext
 import retrofit2.HttpException
 import ru.gildor.coroutines.retrofit.await
 
-class SearchUsers(val name: String): API() {
+class SearchUsers(): API() {
 
 	val api = retrofit.create(UserAPI::class.java)
+	val repo = UserRepository()
 
-	private suspend fun getAsyncUsersList(): List<User> = withContext(CommonPool) {
+	private suspend fun getAsyncUsersList(name: String): List<User> = withContext(CommonPool) {
 		api.searchUsers(name).await()
 	}
 
-	suspend fun getUsersList(): List<User> {
+	suspend fun getUsersList(name : String): List<User> {
 		try {
-			return getAsyncUsersList()
+			return getAsyncUsersList(name)
 
 		} catch (t: HttpException) {
 			throw Exception("update failed.")
 		}
+	}
+
+	fun getUsersListFromDB(name : String)  : RealmResults<User>{
+		return repo.getUsersFromName(name)
 	}
 }

--- a/app/src/main/res/layout/user_select.xml
+++ b/app/src/main/res/layout/user_select.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/user_select"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -11,9 +12,15 @@
         android:layout_width="match_parent"
         android:layout_height="?android:attr/listPreferredItemHeightSmall"
         android:checkMark="?android:attr/listChoiceIndicatorMultiple"
+        android:checked="true"
+        android:clickable="true"
+        android:contextClickable="true"
+        android:cursorVisible="true"
         android:gravity="center_vertical"
         android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
         android:paddingStart="?android:attr/listPreferredItemPaddingStart"
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
+        android:textColor="@android:color/black"
+        tools:checkMarkTint="?attr/colorPrimary"
         tools:text="User Name" />
 </RelativeLayout>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="room_create_input">Room名</string>
+    <string name="room_create_input">ルーム名</string>
     <string name="room_create_button">作成</string>
     <string name="message_input">テキストを入力</string>
     <string name="message_send">送信</string>
@@ -15,4 +15,5 @@
     <string name="message_new_available">新しいメッセージがあります</string>
     <string name="apply">更新</string>
     <string name="apply_button">適用</string>
+    <string name="app_name">SHABEL</string>
 </resources>


### PR DESCRIPTION
## 概要
- UserとRoomのadapterをRealmBaseAdapterに変更しました。

## 実装内容
### Activityから取得するデータはすべてローカルDBから取得するようになりました。(Messageを除く)
- これによりデータの永続化ができるようになりました。
### ListViewのadapterをRealmBaseAdapterを継承したものに変更しました。
- ローカルのDBが別スレッド等で更新されたら表示も自動で変わるようになってます

## 問題
### MessageAcitivityはまだ実装できていません。
- 新着メッセージの通知をどうするか問題が生まれてきたためです。
- 後ストリーミングAPIの影響を一番受けそうな部分なので今触ると手間が増えるだけかもと思ったのも理由の一つです。

